### PR TITLE
Check that `envir` is also installed.

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -33,8 +33,7 @@ view_run_report <- function(
   if(!file.exists(basename(template)))
     file.copy(template, ".")
 
-  if(!requireNamespace("quarto", quietly = TRUE))
-    stop("Please install the {quarto} R package.")
+  rlang::check_installed(pkg = c("quarto", "envir"))
 
   quarto::quarto_render(
     input = basename(template),


### PR DESCRIPTION
I got a 

```
Quitting from lines 15-132 (view-run.qmd) 
Error in library(envir) : there is no package called 'envir'
Calls: .main ... withVisible -> eval_with_user_handlers -> eval -> eval -> library
```

When running `guildai::view_run_report()`.